### PR TITLE
Typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       </div>
       <div class="section">
         <h2>Highly Expressive</h2>
-        <p>A rich hygenic macro system and runtime introspection allows for a wide breadth of programmatic expression. Bend the langauge to your needs rather than bending your needs to the language.</p>
+        <p>A rich hygenic macro system and runtime introspection allows for a wide breadth of programmatic expression. Bend the language to your needs rather than bending your needs to the language.</p>
         <a href="https://github.com/vrtbl/passerine">
           <div class=button>
             Syntactic Macros ↗


### PR DESCRIPTION
`langauge` to `language`, unless it's part of the bend it to your needs idea